### PR TITLE
WrenSec Builds - Phase #1 (for wrensec-util)

### DIFF
--- a/.wren-deploy.rc
+++ b/.wren-deploy.rc
@@ -1,0 +1,3 @@
+export MAVEN_PACKAGE="forgerock-util"
+export BINTRAY_PACKAGE="wrensec-util"
+export JFROG_PACKAGE="org/forgerock/commons/forgerock-utilities"

--- a/forgerock-test-utils/pom.xml
+++ b/forgerock-test-utils/pom.xml
@@ -23,7 +23,7 @@
     </parent>
 
     <artifactId>forgerock-test-utils</artifactId>
-    <name>ForgeRock Utils test utilities</name>
+    <name>Wren Security Utils test utilities</name>
 
     <dependencies>
         <dependency>

--- a/forgerock-util/pom.xml
+++ b/forgerock-util/pom.xml
@@ -21,17 +21,10 @@
         <version>3.0.2</version>
     </parent>
     <artifactId>forgerock-util</artifactId>
-    <name>ForgeRock Utility Classes</name>
-    <description>Miscellaneous utility classes used within ForgeRock projects.</description>
+    <name>Wren Security Utility Classes</name>
+    <description>Miscellaneous utility classes used within Wren Security forks of ForgeRock projects.</description>
     <packaging>bundle</packaging>
-    <url>http://commons.forgerock.org/forgerock-util</url>
-    <distributionManagement>
-        <site>
-            <id>community.internal.forgerock.com</id>
-            <name>ForgeRock Community</name>
-            <url>scp://community.internal.forgerock.com/var/www/vhosts/commons.forgerock.org/httpdocs/forgerock-util</url>
-        </site>
-    </distributionManagement>
+    <url>https://github.com/WrenSecurity/wrensec-util</url>
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
   ~ information: "Portions copyright [year] [name of copyright owner]".
   ~
   ~ Copyright 2015 ForgeRock AS.
+  ~ Portions Copyright © 2017 Wren Security. All rights reserved.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -23,39 +24,31 @@
     <groupId>org.forgerock.commons</groupId>
     <version>3.0.2</version>
     <artifactId>forgerock-utilities</artifactId>
-    <name>ForgeRock Utility Classes Parent</name>
-    <description>Miscellaneous utility classes used within ForgeRock projects.</description>
+    <name>Wren Security Utility Classes Parent</name>
+    <description>Miscellaneous utility classes used within Wren Security forks of ForgeRock projects.</description>
     <packaging>pom</packaging>
-        <url>http://commons.forgerock.org/forgerock-util</url>
+    <url>https://github.com/WrenSecurity/wrensec-util</url>
     <issueManagement>
-        <system>Jira</system>
-        <url>https://bugster.forgerock.org/jira/browse/COMMONS</url>
+        <system>GitHub Issues</system>
+        <url>https://github.com/WrenSecurity/wrensec-util/issues</url>
     </issueManagement>
     <scm>
-        <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-util.git</connection>
-        <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-util.git</developerConnection>
-        <url>http://stash.forgerock.org/projects/COMMONS/repos/forgerock-util/browse</url>
-      <tag>3.0.2</tag>
-  </scm>
-    <ciManagement>
-        <system>jenkins</system>
-        <url>https://builds.forgerock.org/job/Commons%20-%20ForgeRock%20Utils/</url>
-        <notifiers>
-            <notifier>
-                <type>mail</type>
-                <sendOnError>true</sendOnError>
-                <sendOnFailure>true</sendOnFailure>
-                <sendOnSuccess>false</sendOnSuccess>
-                <sendOnWarning>false</sendOnWarning>
-            </notifier>
-        </notifiers>
-    </ciManagement>
+        <url>https://github.com/WrenSecurity/wrensec-util</url>
+        <connection>scm:git:git://github.com/WrenSecurity/wrensec-util.git</connection>
+        <developerConnection>scm:git:git@github.com:WrenSecurity/wrensec-util.git</developerConnection>
+    </scm>
     <distributionManagement>
-        <site>
-            <id>community.internal.forgerock.com</id>
-            <name>ForgeRock Community</name>
-            <url>scp://community.internal.forgerock.com/var/www/vhosts/commons.forgerock.org/httpdocs/forgerock-util</url>
-        </site>
+        <snapshotRepository>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Snapshot Repository</name>
+            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-util/;publish=1</url>
+        </snapshotRepository>
+
+        <repository>
+            <id>bintray-wrensecurity-snapshots</id>
+            <name>Wren Security Release Repository</name>
+            <url>${forgerockDistMgmtReleasesUrl}/wrensec-util/;publish=1</url>
+        </repository>
     </distributionManagement>
     <properties>
         <clirrComparisonVersion>1.3.0</clirrComparisonVersion>
@@ -77,12 +70,17 @@
     </dependencyManagement>
     <repositories>
         <repository>
-            <id>forgerock-staging-repository</id>
-            <name>ForgeRock Release Repository</name>
-            <url>http://maven.forgerock.org/repo/releases</url>
+            <id>bintray-wrensecurity-releases</id>
+            <name>Wren Security Release Repository</name>
+            <url>http://dl.bintray.com/wrensecurity/releases</url>
+
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
+
+            <releases>
+                <enabled>true</enabled>
+            </releases>
         </repository>
     </repositories>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -39,15 +39,15 @@
     </scm>
     <distributionManagement>
         <snapshotRepository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-snapshots</id>
             <name>Wren Security Snapshot Repository</name>
-            <url>${forgerockDistMgmtSnapshotsUrl}/wrensec-util/;publish=1</url>
+            <url>${forgerockDistMgmtSnapshotsUrl}</url>
         </snapshotRepository>
 
         <repository>
-            <id>bintray-wrensecurity-snapshots</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>${forgerockDistMgmtReleasesUrl}/wrensec-util/;publish=1</url>
+            <url>${forgerockDistMgmtReleasesUrl}</url>
         </repository>
     </distributionManagement>
     <properties>
@@ -69,10 +69,11 @@
         </dependencies>
     </dependencyManagement>
     <repositories>
+        <!-- Needed to retrieve parent POM -->
         <repository>
-            <id>bintray-wrensecurity-releases</id>
+            <id>wrensecurity-releases</id>
             <name>Wren Security Release Repository</name>
-            <url>http://dl.bintray.com/wrensecurity/releases</url>
+            <url>https://wrensecurity.jfrog.io/wrensecurity/releases</url>
 
             <snapshots>
                 <enabled>false</enabled>


### PR DESCRIPTION
- modifies the POMs to build using Wren's repos.
- updates branding to call this Wren Security Utils instead of ForgeRock Utils.
- adds [Wren Deploy](https://github.com/WrenSecurity/wrensec-deploy-tool) RC file.
- the `sustaining/*` branches have already been updated with similar changes.